### PR TITLE
feature: custom bases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ path = "tests/base32_hex.rs"
 [[test]]
 name = "base45"
 path = "tests/base45.rs"
+
+[features]
+custom_bases = []


### PR DESCRIPTION
Allow custom basex encoding and decoding.
A user supplied base alphabet table is needed for both functionalities to work.